### PR TITLE
use registry.access.redhat.com/ubi8-minimal for multi-arch support

### DIFF
--- a/roots2i/Dockerfile
+++ b/roots2i/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/quay/busybox:latest
+FROM registry.access.redhat.com/ubi8-minimal:latest
 
 LABEL io.openshift.s2i.scripts-url="image:///usr/libexec/s2i"
 

--- a/simples2i/Dockerfile
+++ b/simples2i/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/quay/busybox:latest
+FROM registry.access.redhat.com/ubi8-minimal:latest
 
 LABEL io.openshift.s2i.scripts-url="image:///usr/libexec/s2i"
 


### PR DESCRIPTION
Unfortunately, quay.io/quay/busybox is single-arch.

/cc @gabemontero
