### PR TITLE
Added nonroot USER to the 'simples2i' image

### DIFF
--- a/simples2i/Dockerfile
+++ b/simples2i/Dockerfile
@@ -3,5 +3,5 @@ FROM registry.access.redhat.com/ubi8-minimal:latest
 LABEL io.openshift.s2i.scripts-url="image:///usr/libexec/s2i"
 
 ADD s2i /usr/libexec/s2i
+USER 1001
 CMD ["/usr/libexec/s2i/run"]
-


### PR DESCRIPTION
`ubi8`'s default user is root, and we don't want to have root as default user in our `s2i` images unless we run specific tests
(as in `roots2i` case).
Therefore, changing default user in the `simples2i` `Dockerfile`.