### PR TITLE
Build FROM ubi8

### DIFF
--- a/roots2i/Dockerfile
+++ b/roots2i/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8-minimal:latest
+FROM registry.access.redhat.com/ubi8:latest
 
 LABEL io.openshift.s2i.scripts-url="image:///usr/libexec/s2i"
 

--- a/simples2i/Dockerfile
+++ b/simples2i/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8-minimal:latest
+FROM registry.access.redhat.com/ubi8:latest
 
 LABEL io.openshift.s2i.scripts-url="image:///usr/libexec/s2i"
 


### PR DESCRIPTION
The build-quota test runs the findmnt command in its assemble script. 
While the full ubi8 includes util-linux, ubi8-minimal does not.

Not sure how this slipped through testing of https://github.com/openshift/build-test-images/pull/7 but it was noticed via https://github.com/openshift/release/pull/18939.

/cc @gabemontero @alicerum
